### PR TITLE
Prepare for encrypted keys

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bonusly_dashboard (0.1.30)
+    bonusly_dashboard (0.1.31)
       font-awesome-sass (>= 4.6.2)
       secure_headers
 

--- a/app/controllers/bonusly_dashboard/dashboard_controller.rb
+++ b/app/controllers/bonusly_dashboard/dashboard_controller.rb
@@ -2,7 +2,7 @@ module BonuslyDashboard
   class DashboardController < ApplicationController
     skip_after_filter :intercom_rails_auto_include
     after_filter :allow_iframe, only: :index
-    before_filter :ensure_access_token, only: :index
+    before_filter :ensure_api_key, only: :index
 
     def index
       override_x_frame_options('ALLOW-FROM *')
@@ -43,8 +43,8 @@ module BonuslyDashboard
       @api_key ||= ApiKey.for_access_token(access_token).first
     end
 
-    def ensure_access_token
-      raise 'No access token provided' unless access_token.present?
+    def ensure_api_key
+      render text: 'Invalid access token provided', status: 401 unless api_key.present?
     end
 
     def allow_iframe

--- a/app/controllers/bonusly_dashboard/dashboard_controller.rb
+++ b/app/controllers/bonusly_dashboard/dashboard_controller.rb
@@ -2,9 +2,15 @@ module BonuslyDashboard
   class DashboardController < ApplicationController
     skip_after_filter :intercom_rails_auto_include
     after_filter :allow_iframe, only: :index
+    before_filter :ensure_access_token, only: :index
 
     def index
       override_x_frame_options('ALLOW-FROM *')
+
+      @access_token = access_token
+      @company      = company
+      @theme_color  = theme_color
+
       render layout: false
     end
 
@@ -14,6 +20,33 @@ module BonuslyDashboard
     end
 
     private
+
+    def access_token
+      @access_token ||= params[:access_token].presence || current_user&.api_key&.access_token
+    end
+
+    def company
+      @company ||= begin
+        if api_key&.api_authenticatable.is_a?(Company)
+          api_key.api_authenticatable
+        elsif api_key&.api_authenticatable.is_a?(User) && api_key.api_authenticatable.active?
+          api_key.api_authenticatable.company
+        end
+      end
+    end
+
+    def theme_color
+      company.nil? ? BONUSLY::THEMES['dark']['brand'] : company_theme(company)[:brand]
+    end
+
+    def api_key
+      @api_key ||= ApiKey.for_access_token(access_token).first
+    end
+
+    def ensure_access_token
+      raise 'No access token provided' unless access_token.present?
+    end
+
     def allow_iframe
       response.headers.except! 'X-Frame-Options'
     end

--- a/app/views/bonusly_dashboard/dashboard/index.html.erb
+++ b/app/views/bonusly_dashboard/dashboard/index.html.erb
@@ -1,19 +1,3 @@
-<%
-  access_token = params[:access_token].presence || current_user&.api_key&.access_token
-  raise 'No access token provided' unless access_token.present?
-  api_key = ApiKey.where(access_token: access_token).first
-
-  company = nil
-  if api_key&.api_authenticatable.is_a?(Company)
-    company = api_key.api_authenticatable
-  elsif api_key&.api_authenticatable.is_a?(User) && api_key.api_authenticatable.active?
-    company = api_key.api_authenticatable.company
-  end
-
-  theme_color = company.nil? ? BONUSLY::THEMES['dark']['brand'] : company_theme(company)[:brand]
-%>
-
-
 <!DOCTYPE html>
 <html>
   <head>
@@ -21,9 +5,9 @@
     <%= stylesheet_link_tag 'index' %>
 
     <style type="text/css">
-      body, .highlights, .highlighted-bonus-total-value { background-color: <%= theme_color %>; }
-      .inline-bonus-amount, .highlighted-bonus-name, .user-link, #bonus-reason > a[target='_blank'] { color: <%= theme_color %>; }
-      .inline-bonus-amount { border: 0.1em solid <%= theme_color %>; }
+      body, .highlights, .highlighted-bonus-total-value { background-color: <%= @theme_color %>; }
+      .inline-bonus-amount, .highlighted-bonus-name, .user-link, #bonus-reason > a[target='_blank'] { color: <%= @theme_color %>; }
+      .inline-bonus-amount { border: 0.1em solid <%= @theme_color %>; }
     </style>
     <%= javascript_include_tag 'jquery-1.12.4.min.js' %>
     <%= javascript_include_tag 'Util.js' %>
@@ -36,8 +20,8 @@
     <%= javascript_include_tag 'app.js' %>
   </head>
   <body class="highlights"
-        data-access-token="<%= access_token %>"
-        data-company-name="<%= company&.name %>" >
+        data-access-token="<%= @access_token %>"
+        data-company-name="<%= @company&.name %>" >
 
 
     <!-- Bonus Container -->

--- a/app/views/bonusly_dashboard/dashboard/index.html.erb
+++ b/app/views/bonusly_dashboard/dashboard/index.html.erb
@@ -1,5 +1,6 @@
 <%
-  access_token = current_user.nil? ? params[:access_token] : current_user.api_key.access_token
+  access_token = params[:access_token].presence || current_user&.api_key&.access_token
+  raise 'No access token provided' unless access_token.present?
   api_key = ApiKey.where(access_token: access_token).first
 
   company = nil

--- a/bonusly_dashboard.gemspec
+++ b/bonusly_dashboard.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.name        = 'bonusly_dashboard'
-  s.version     = '0.1.30'
-  s.date        = '2016-05-27'
+  s.version     = '0.1.31'
+  s.date        = '2016-11-29'
   s.summary     = 'Bonusly Dashboard'
   s.description = 'A simple dashboard for displaying recent Bonusly highlights'
   s.authors     = ['Aaron Davis', 'Robert Ingrum']


### PR DESCRIPTION
Cleans up a bit, but the behavioral differences are:

1. Prefer `params[:access_token]` over the `current_user`'s api key
2. Uses `ApiKey.for_access_token` so that we can hang out with encrypted keys
3. Render "Invalid access token" if we can't find the API key.