### PR TITLE
Update for Rails 5

### DIFF
--- a/app/controllers/bonusly_dashboard/dashboard_controller.rb
+++ b/app/controllers/bonusly_dashboard/dashboard_controller.rb
@@ -76,7 +76,7 @@ module BonuslyDashboard
     end
 
     def ensure_api_key
-      render text: 'Invalid access token provided', status: 401 unless api_key.present?
+      render plain: 'Invalid access token provided', status: 401 unless api_key.present?
     end
   end
 end

--- a/bonusly_dashboard.gemspec
+++ b/bonusly_dashboard.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'bonusly_dashboard'
-  s.version     = '0.2.4'
+  s.version     = '0.2.5'
   s.date        = '2017-09-01'
   s.summary     = 'Bonusly Dashboard'
   s.description = 'A simple dashboard for displaying recent Bonusly highlights'


### PR DESCRIPTION
`render :text` is deprecated in Rails 5 and is causing errors when an API key is invalid / missing