### PR TITLE
Fix Data Passthrough

### DIFF
--- a/app/assets/javascripts/BonuslyDashboard.js
+++ b/app/assets/javascripts/BonuslyDashboard.js
@@ -7,7 +7,7 @@ function BonuslyDashboard(options) {
     bonusApiUri:     '/api/v1/bonuses',
     statApiUri:      '/api/v1/stats',
     analyticsApiUri: '/api/v1/instrumentation/events',
-    versionApiUri:   '/company/dashboard/version'
+    versionApiUri:   '/company/digital_signage/version'
   };
 
   $.extend(this.config, options);

--- a/app/assets/javascripts/Manager.js
+++ b/app/assets/javascripts/Manager.js
@@ -11,7 +11,7 @@ function Manager(dashboard) {
   this.analyticsApi = dashboard.config.analyticsApiUri;
   this.analyticsParams = $.param({
     access_token: dashboard.config.accessToken,
-    category: 'dashboard',
+    category: 'digital-signage',
     event: 'fetch',
     label: $('body').data('company-name')
   });
@@ -43,7 +43,7 @@ Manager.prototype = {
     var callback_set_id = this.callback_set_id = Math.floor(Math.random() * 10e10);
     this.callback_count = Object.keys(this.subManagers).length;
 
-    $.getJSON( '/company/dashboard/data?' + this.dataParams )
+    $.getJSON( '/company/digital_signage/data?' + this.dataParams )
         .done( function(data) {
           if (data.success === false) return self.handleCallbackFailure();
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   get 'company/dashboard', to: redirect(path: 'company/digital_signage')
   get 'company/dashboard/version', to: redirect('company/digital_signage/version')
-  get 'company/dashboard/data', to: redirect('company/digital_signage/data')
+  get 'company/dashboard/data', to: redirect(path: 'company/digital_signage/data')
   get 'company/digital_signage' => 'bonusly_dashboard/dashboard#index'
   get 'company/digital_signage/version' => 'bonusly_dashboard/dashboard#version'
   get 'company/digital_signage/data' => 'bonusly_dashboard/dashboard#data'


### PR DESCRIPTION
Data stopped coming through to the dash after the last update. Turns out I missed a spot where we were still using the old route and the redirect without the path won't work because we need the access token