### PR TITLE
Let's include lengthier bonuses so people don't get confused by their absence

### DIFF
--- a/app/assets/javascripts/BonuslyDashboard.js
+++ b/app/assets/javascripts/BonuslyDashboard.js
@@ -4,8 +4,6 @@ function BonuslyDashboard(options) {
     messageInterval: Util.seconds(10),
     refreshInterval: Util.minutes(5),
     bonusLimit:      '50',
-    bonusApiUri:     '/api/v1/bonuses',
-    statApiUri:      '/api/v1/stats',
     analyticsApiUri: '/api/v1/instrumentation/events',
     versionApiUri:   '/company/digital_signage/version'
   };

--- a/app/assets/javascripts/Util.js
+++ b/app/assets/javascripts/Util.js
@@ -1,5 +1,5 @@
 var Util = {
-  
+
   getUrlParams: function() {
     var result = [];
 
@@ -14,7 +14,7 @@ var Util = {
 
     return result;
   },
-  
+
   timeSince: function(date) {
     var seconds = Math.floor((new Date() - date) / 1000);
     var interval = Math.floor(seconds / 31536000);
@@ -40,11 +40,11 @@ var Util = {
     }
     return Math.floor(seconds) + " seconds";
   },
-  
+
   seconds: function(seconds) { return seconds * 1000; },
-  
+
   minutes: function(minutes) { return minutes * 1000 * 60; },
-  
+
   days: function(days) { return days * 1000 * 60 * 60 * 24 },
 
   shuffle: function(arr) {
@@ -53,8 +53,8 @@ var Util = {
   },
 
   useBonus: function(bonus) {
-    return (bonus.receivers.length <= 5 &&
-            Util.getLength(bonus) <= 200);
+    return (bonus.receivers.length <= 10 &&
+            Util.getLength(bonus) <= 800);
   },
 
   getLength: function(bonus) {

--- a/app/views/bonusly_dashboard/dashboard/index.html.erb
+++ b/app/views/bonusly_dashboard/dashboard/index.html.erb
@@ -21,7 +21,7 @@
 
     <% if @access_token.blank? %>
       <div class="not-authenticated">
-        <header><img src="https://production-cdn.bonus.ly/assets/logo/bonusly_logo_and_name_large_dark.png" width="250px"></header>
+        <header><img src="https://production-cdn.bonus.ly/assets/logo/bonusly_logo_and_name_large_dark-b524c2bdea966d8a5e56f8b03a2779943390baec43f6bb85832203b46e4a71f8.png" width="250px"></header>
 
         <h2>Please enter your access token:</h2>
         <%= form_tag({}, method: :get) do %>

--- a/bonusly_dashboard.gemspec
+++ b/bonusly_dashboard.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'bonusly_dashboard'
-  s.version     = '1.0.0'
+  s.version     = '1.0.1'
   s.date        = '2017-09-01'
   s.summary     = 'Bonusly Dashboard'
   s.description = 'A simple dashboard for displaying recent Bonusly highlights'


### PR DESCRIPTION
1. Minor cleanup
2. Fixes path to logo
3. Expands our restrictions on bonuses to show from 5 to 10 receivers and from 200 to 800 characters.

Still looks fine:

<img width="1601" alt="Screen Shot 2020-09-21 at 4 16 00 PM" src="https://user-images.githubusercontent.com/225802/93827174-f86b6a00-fc25-11ea-9a41-8cb9f48bde40.png">
