### PR TITLE
Fix displaying digital signage within an iframe

### DIFF
--- a/app/controllers/bonusly_dashboard/dashboard_controller.rb
+++ b/app/controllers/bonusly_dashboard/dashboard_controller.rb
@@ -91,7 +91,8 @@ module BonuslyDashboard
     def set_cookie
       cookies[:access_token] = {
         value: params[:access_token].presence || current_user&.api_key&.access_token || cookies[:access_token] || session[:access_token],
-        secure: !(Rails.env.development? || Rails.env.test?)
+        secure: !(Rails.env.development? || Rails.env.test?),
+        same_site: :none
       }
       redirect_to params.permit!.except(:access_token) if params[:access_token].present?
     end

--- a/app/controllers/bonusly_dashboard/dashboard_controller.rb
+++ b/app/controllers/bonusly_dashboard/dashboard_controller.rb
@@ -2,7 +2,7 @@ module BonuslyDashboard
   class DashboardController < ApplicationController
     skip_after_action :intercom_rails_auto_include
     before_action     :set_x_frame_options_header
-    before_action     :set_session, :ensure_api_key, only: :index
+    before_action     :set_cookie, :ensure_api_key, only: :index
 
     def index
       @access_token = access_token
@@ -52,8 +52,10 @@ module BonuslyDashboard
       @bonuses ||= Bonuses.new(base_url: request.base_url, params: api_params)
     end
 
+    # Falling back to session to not break open dashboards while migrating to
+    # cookies for iframe support
     def access_token
-      session[:access_token]
+      cookies[:access_token] || session[:access_token]
     end
 
     def api_params
@@ -83,11 +85,14 @@ module BonuslyDashboard
     end
 
     def ensure_api_key
-      session[:access_token] = nil if api_key.nil?
+      cookies[:access_token] = nil if api_key.nil?
     end
 
-    def set_session
-      session[:access_token] = params[:access_token].presence || current_user&.api_key&.access_token || session[:access_token]
+    def set_cookie
+      cookies[:access_token] = {
+        value: params[:access_token].presence || current_user&.api_key&.access_token || cookies[:access_token] || session[:access_token],
+        secure: !(Rails.env.development? || Rails.env.test?)
+      }
       redirect_to params.permit!.except(:access_token) if params[:access_token].present?
     end
   end


### PR DESCRIPTION
The default session cookies won't work for pages in an iframe, but cookies set with `SameSite=None; Secure` do.

Further reading: https://medium.com/trabe/cookies-and-iframes-f7cca58b3b9e

Screenshot:

<img width="1317" alt="Screen Shot 2021-01-06 at 9 32 36 AM" src="https://user-images.githubusercontent.com/225802/103794607-283a5400-5002-11eb-8a9e-67e987777575.png">

Displaying within an iframe still isn't *advisable* but this makes the digital signage work with things like [Mvix's Video Wall](https://www.mvixusa.com/videowall/)