### PR TITLE
change URI.escape

### DIFF
--- a/app/models/bonusly_dashboard/api_data.rb
+++ b/app/models/bonusly_dashboard/api_data.rb
@@ -45,7 +45,7 @@ module BonuslyDashboard
     end
 
     def urlized_params
-      URI.escape(relevant_params.map { |key, value| "#{key}=#{value}" }.join('&'))
+      URI.encode_www_form(relevant_params.map { |key, value| "#{key}=#{value}" }.join('&'))
     end
 
     def endpoint


### PR DESCRIPTION
This is the second part of https://app.clubhouse.io/bonusly/story/8663/replace-obsolete-uri-encode-escape

## What's this do?

[Clubhouse Story](https://app.clubhouse.io/bonusly/story/8663/replace-obsolete-uri-encode-escape)
While [Ruby Docs](https://ruby-doc.org/stdlib-2.7.0/libdoc/uri/rdoc/URI/Escape.html#method-i-encode) still very politely describe the interface of `URI.encode`, they also pretty firmly say it's obsolete, and tell us to use [this method](https://ruby-doc.org/stdlib-2.7.0/libdoc/uri/rdoc/URI.html#method-c-encode_www_form_component) instead.

## What's risky about it?

encoding. This method is slightly different than `URI.escape`, apparently: https://stackoverflow.com/questions/65423458/ruby-2-7-says-uri-escape-is-obsolete-what-replaces-it

Could this possibly have implications for the FE? 

## Screenshots
![surprise](https://media.giphy.com/media/ik4WNB1HLOHDy/giphy.gif)

Tested on local. Digital signage seemed to look fine.
